### PR TITLE
Check for pe master

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Overwrite the existing /opt/puppetlabs/server/apps/puppetserver/bin/generate-pup
 
 Example Usage
 
-Add the class codemgmt_1055_hotfix to the PE Master node group in the PE Classifier.  Execute a Puppet agent run on the masters to enforce the updated file resource.
+Add the class codemgmt_1055_hotfix to a node group containing only the PE master node in the PE Classifier.  Execute a Puppet agent run on the PE master to enforce the updated file resource.
 
 The bug in question manifests as Code Manager code deploys hanging.  If the inability to deploy code is preventing the deployment of this hotfix module, disable environment isolation temporarily using the instructions at https://docs.puppet.com/puppet/4.10/environment_isolation.html#troubleshooting-environment-isolation.  Once the module is deployed, re-enable environment isolation.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 class codemgmt_1055_hotfix {
-  if($::pe_server_version != "") {
-    if ((versioncmp('2017.2.0', $::pe_server_version) > 0) and (versioncmp('2016.5.0', $::pe_server_version) < 0)){
+  if(has_key($facts, 'pe_server_version')) {
+    if ((versioncmp('2017.2.0', $facts['pe_server_version']) > 0) and (versioncmp('2016.5.0', $facts['pe_server_version']) < 0)){
       file {'/opt/puppetlabs/server/apps/puppetserver/bin/generate-puppet-types.rb':
         ensure => file,
         source => 'puppet:///modules/codemgmt_1055_hotfix/generate-puppet-types.rb',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,11 +1,13 @@
 class codemgmt_1055_hotfix {
-  if ((versioncmp('2017.2.0', $::pe_server_version) > 0) and (versioncmp('2016.5.0', $::pe_server_version) < 0)){
-    file {'/opt/puppetlabs/server/apps/puppetserver/bin/generate-puppet-types.rb':
-      ensure => file,
-      source => 'puppet:///modules/codemgmt_1055_hotfix/generate-puppet-types.rb',
-      mode   => '0755',
-      owner  => 'root',
-      group  => 'root',
+  if($::pe_server_version != "") {
+    if ((versioncmp('2017.2.0', $::pe_server_version) > 0) and (versioncmp('2016.5.0', $::pe_server_version) < 0)){
+      file {'/opt/puppetlabs/server/apps/puppetserver/bin/generate-puppet-types.rb':
+        ensure => file,
+        source => 'puppet:///modules/codemgmt_1055_hotfix/generate-puppet-types.rb',
+        mode   => '0755',
+        owner  => 'root',
+        group  => 'root',
+      }
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "abottchen-codemgmt_1055_hotfix",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "abottchen",
   "summary": "Hotfix to address known issue with `puppet generate types` blocking on reads from stdout",
   "license": "Apache-2.0",


### PR DESCRIPTION
I didn't like that compile masters would try to apply the class.  Now we check for pe_server_version.  Also flipped to using the facts hash just to be consistent with best practices.